### PR TITLE
Fh 4454

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ ICAgdHlwZTogc3RyaW5nCiAgICAgIHRpdGxlOiB5b3VyIG5ldyBhcHBzIG5hbWUK"
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
+COPY mobile /usr/bin
 RUN chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/roles/deprovision-ios-app/tasks/main.yml
+++ b/roles/deprovision-ios-app/tasks/main.yml
@@ -1,5 +1,3 @@
-- k8s_v1_config_map:
-    labels:
-      - name: '{{ appName }}'
-    namespace: '{{ namespace }}'
-    state: absent
+# Delete iOS app representation using the mobile cli
+- name: "Delete iOS app representation"
+  shell: mobile delete client {{ appName }}-ios --namespace={{ namespace }}

--- a/roles/provision-ios-app/defaults/main.yml
+++ b/roles/provision-ios-app/defaults/main.yml
@@ -1,1 +1,0 @@
-app_description: "iOS App"

--- a/roles/provision-ios-app/tasks/main.yml
+++ b/roles/provision-ios-app/tasks/main.yml
@@ -1,28 +1,3 @@
-- name: "Generate a unique app name"
-  shell: "echo \"{{ appName }}-$(date +%s)\""
-  register: app_unique_name
-
-- name: "Generate an api key"
-  shell: "uuidgen"
-  register: api_key
-
-- name: Create Mobile App Resource
-  k8s_v1_config_map:
-    state: "present"
-    name: "{{ app_unique_name.stdout }}"
-    namespace: "{{ namespace }}"
-    resource_definition:
-      kind: "ConfigMap"
-      apiVersion: "v1"
-      metadata:
-        name: "{{ app_unique_name.stdout }}"
-        namespace: "{{ namespace }}"
-        labels:
-          group: "mobileapp"
-          name: "{{ appName }}"
-      data:
-        name: "{{ appName }}"
-        displayName: "{{ appName }}"
-        clientType: "ios"
-        apiKey: "{{ api_key.stdout }}"
-        description: "{{ app_description }}"
+# Creates an iOS app representation using the mobile cli
+- name: "Create iOS app representation"
+  shell: mobile create client {{ appName }} iOS --namespace={{ namespace }}


### PR DESCRIPTION
Use the mobile-cli to create mobile app representations in the APBs. This is to ensure that the definition of a mobile app is the same whether it's created through the APB or the mobile-cli.

This PR adds the precompiled (linux/amd64) mobile-cli binary to the container which is ~50 Mb. Whenever the APB is updated we should also include the newest mobile-cli. Another option would be to pull the mobile-cli repo into the container and build it there.

ping @david-martin @maleck13 @StevenTobin @wtrocki