### PR TITLE
[AEROGEAR-2137] Update APB to create valid mobile resource

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -18,4 +18,8 @@ plans:
       required: True
       default: myapp
       type: string
-      title: your new apps name
+      title: Application Name
+    - name: appIdentiifer
+      required: True
+      type: string
+      title: Bundle ID

--- a/roles/provision-ios-app/tasks/main.yml
+++ b/roles/provision-ios-app/tasks/main.yml
@@ -1,3 +1,3 @@
 # Creates an iOS app representation using the mobile cli
 - name: "Create iOS app representation"
-  shell: mobile create client {{ appName }} iOS --namespace={{ namespace }}
+  shell: mobile create client {{ appName }} iOS {{ appIdentiifer }} --namespace={{ namespace }}


### PR DESCRIPTION
## Description
Updated APB to accept an app identifier parameter and update the mobile cli binary to the latest version

## Progress
- [x] Update to accept an app identifier parameter
- [x] Update mobile cli binary

## Related Notes
Related Ticket - https://issues.jboss.org/browse/AEROGEAR-2137